### PR TITLE
Rename import herring to smdistributed.dataparallel

### DIFF
--- a/models/nlp/albert/run_pretraining.py
+++ b/models/nlp/albert/run_pretraining.py
@@ -62,10 +62,10 @@ from common.utils import (
 )
 
 # See https://github.com/huggingface/transformers/issues/3782; this import must come last
-import herring.tensorflow as herring  # isort:skip
+import smdistributed.dataparallel.tensorflow as herring  # isort:skip
 import herringcommon as hc
 bucket_cap_bytes = int(64 * 1024 * 1024)
-hc.setBucketSize(bucket_cap_bytes) # TODO : Change to obfuscate herringcommon. This code does not use GradientTape, so need to pass it like this. 
+hc.setBucketSize(bucket_cap_bytes) # TODO : Change to obfuscate herringcommon. This code does not use GradientTape, so need to pass it like this.
 herring.init()
 
 if is_wandb_available():

--- a/models/nlp/common/datasets.py
+++ b/models/nlp/common/datasets.py
@@ -64,7 +64,7 @@ def get_dataset_from_tfrecords(
     # Shard and shuffle the filenames
     dataset = tf.data.Dataset.from_tensor_slices(filenames)
     if shard:
-        import herring.tensorflow as herring
+        import smdistributed.dataparallel.tensorflow as herring
 
         dataset = dataset.shard(herring.size(), herring.rank())
     dataset = dataset.shuffle(buffer_size=len(filenames), reshuffle_each_iteration=True)

--- a/models/nlp/common/utils.py
+++ b/models/nlp/common/utils.py
@@ -25,7 +25,7 @@ from transformers.data.processors.squad import (
 from common.arguments import ModelArguments
 
 # See https://github.com/huggingface/transformers/issues/3782; this import must come last
-import herring.tensorflow as herring  # isort:skip
+import smdistributed.dataparallel.tensorflow as herring  # isort:skip
 
 try:
     import wandb


### PR DESCRIPTION
- Renamed import `herring` to `smdistributed.dataparallel`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
