### PR TITLE
Fixed imports for herringcommon module

### DIFF
--- a/models/nlp/albert/run_pretraining.py
+++ b/models/nlp/albert/run_pretraining.py
@@ -68,10 +68,7 @@ import smdistributed.dataparallel.tensorflow as smddp  # isort:skip
 
 # TODO : Change to obfuscate smddpcommon. This code does not use GradientTape, so need to pass it like this.
 bucket_cap_bytes = int(64 * 1024 * 1024)
-if _PRE_TF_2_4_0:
-    import herringcommon as hc
-else:
-    import smddpcommon as hc
+import smddpcommon as hc
 hc.setBucketSize(bucket_cap_bytes)
 
 smddp.init()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Due to recent changes in the smddp master branch, the nightly CI was failing on BERT pre-training on EC2, as it pulled from herring master. 
This PR should fix that. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
