### PR TITLE
Unpin pyarrow version so bert works with py39

### DIFF
--- a/models/nlp/albert/requirements.sh
+++ b/models/nlp/albert/requirements.sh
@@ -5,6 +5,6 @@ pip install --no-cache-dir \
         colorama==0.4.3 \
         pandas \
         apache_beam \
-        pyarrow==0.16 \
+        pyarrow \
         git+https://github.com/HerringForks/transformers.git@master \
         git+https://github.com/huggingface/nlp.git@703b761


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Unpins pyarrow version to work with python 3.9

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
